### PR TITLE
Adding Plugin to display kernel status in text

### DIFF
--- a/kernel_text_status/README.md
+++ b/kernel_text_status/README.md
@@ -1,0 +1,32 @@
+# kernel_text_status
+
+Extension to display status of kernel through text for easy readability
+
+
+## Prerequisites
+
+* JupyterLab
+
+## Installation
+
+```bash
+jupyter labextension install kernel_text_status
+```
+
+## Development
+
+For a development install (requires npm version 4 or later), do the following in the repository directory:
+
+```bash
+npm install
+npm run build
+jupyter labextension link .
+```
+
+To rebuild the package and the JupyterLab app:
+
+```bash
+npm run build
+jupyter lab build
+```
+

--- a/kernel_text_status/package.json
+++ b/kernel_text_status/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "kernel_text_status",
+  "version": "0.1.0",
+  "description": "Extension to display status of kernel through text for easy readability",
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "jupyterlab-extension"
+  ],
+  "homepage": "https://github.com/my_name/myextension",
+  "bugs": {
+    "url": "https://github.com/my_name/myextension/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "imam.k",
+  "files": [
+    "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/my_name/myextension.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "prepare": "npm run clean && npm run build",
+    "watch": "tsc -w"
+  },
+  "dependencies": {
+    "@jupyterlab/application": "^0.17.2",
+    "@jupyterlab/apputils": "^0.17.2",
+    "@jupyterlab/docregistry": "^0.17.2",
+    "@jupyterlab/notebook": "^0.17.2",
+    "@phosphor/disposable": "^1.1.3"
+  },
+  "devDependencies": {
+    "rimraf": "^2.6.1",
+    "typescript": "~3.1.1"
+  },
+  "jupyterlab": {
+    "extension": true
+  }
+}

--- a/kernel_text_status/src/index.ts
+++ b/kernel_text_status/src/index.ts
@@ -27,7 +27,7 @@ const TOOLBAR_KERNEL_NAME_CLASS = 'jp-Toolbar-kernelName';
  */
  const plugin: JupyterLabPlugin<void> = {
  	activate,
- 	id: 'my-extension-name:buttonPlugin',
+ 	id: 'fk_extension:kernelTextPlugin',
  	autoStart: true
  };
 

--- a/kernel_text_status/src/index.ts
+++ b/kernel_text_status/src/index.ts
@@ -1,0 +1,89 @@
+import {
+	IDisposable, DisposableDelegate
+} from '@phosphor/disposable';
+
+import {
+	JupyterLab, JupyterLabPlugin
+} from '@jupyterlab/application';
+
+import {
+	ToolbarButton,
+	IClientSession
+} from '@jupyterlab/apputils';
+
+import {
+	DocumentRegistry
+} from '@jupyterlab/docregistry';
+
+import {
+	NotebookPanel, INotebookModel
+} from '@jupyterlab/notebook';
+
+
+const TOOLBAR_KERNEL_NAME_CLASS = 'jp-Toolbar-kernelName';
+
+/**
+ * The plugin registration information.
+ */
+ const plugin: JupyterLabPlugin<void> = {
+ 	activate,
+ 	id: 'my-extension-name:buttonPlugin',
+ 	autoStart: true
+ };
+
+ export class KernelStatusTextBox extends ToolbarButton {
+
+ 	constructor(session: IClientSession) {
+ 		super({
+ 			className: TOOLBAR_KERNEL_NAME_CLASS,
+ 		});
+ 		this._onStatusChanged(session);
+ 		session.statusChanged.connect(this._onStatusChanged,this);
+ 	}
+
+ 	private _onStatusChanged(session: IClientSession) {
+ 		if (this.isDisposed){
+ 			return;
+ 		}
+
+ 		let status = session.status;
+ 		let title  = 'Kernel ' + status[0].toUpperCase() + status.slice(1);
+ 		this.node.textContent = title;
+ 	}
+
+ }
+
+/**
+ * A notebook widget extension that adds a button to the toolbar.
+ */
+ export
+ class KernelTextStatusButtonExtension implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {
+  /**
+   * Create a new extension object.
+   */
+   createNew(panel: NotebookPanel, context: DocumentRegistry.IContext<INotebookModel>): IDisposable {
+
+   		let button = new KernelStatusTextBox(panel.session);
+
+   		panel.toolbar.insertItem(12, 'runAll', button);
+   		return new DisposableDelegate(() => {
+   			button.dispose();
+   		});
+
+
+   	}
+
+   }
+
+/**
+ * Activate the extension.
+ */
+ function activate(app: JupyterLab) {
+ 	app.docRegistry.addWidgetExtension('Notebook', new KernelTextStatusButtonExtension());
+ };
+
+
+/**
+ * Export the plugin as default.
+ */
+ export default plugin;

--- a/kernel_text_status/tsconfig.json
+++ b/kernel_text_status/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "lib": ["es2015", "dom"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noUnusedLocals": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "strict": true,
+    "strictNullChecks": false,
+    "target": "es2015",
+    "types": []
+  },
+  "include": ["src/*"]
+}


### PR DESCRIPTION
Installing this plugin will add a new button on the toolbar of jupyter lab to display the kernel status in a text mode